### PR TITLE
:green_heart: Pin click version

### DIFF
--- a/daft/evaluate.py
+++ b/daft/evaluate.py
@@ -141,7 +141,7 @@ def get_metrics(model: Module, data_loader: DataLoader, train_y: np.ndarray) -> 
     times = np.quantile(y_all["time"][y_all["event"]], q / 100.0)
 
     auc_t, auc = cumulative_dynamic_auc(train_y, test_y, logits, times=times)
-    data = pd.Series(dict(zip(map(lambda x: f"AUC({int(x)})", q), auc_t)))
+    data = pd.Series(dict(zip(map(lambda x: f"AUC({int(x)})", q), auc_t)))  # noqa: C417
     data.loc["iAUC"] = auc
 
     cindex_ipcw = concordance_index_ipcw(train_y, test_y, logits)

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ basepython = python3
 skip_install = true
 deps =
     black==19.10b0
+    click==8.0.4
 commands = black -t py37 -l 120 --check --diff daft/ train.py ablation_adni_survival.py ablation_adni_classification.py
 
 [testenv:isort]


### PR DESCRIPTION
CI fails with

```
Traceback (most recent call last):
  File "/home/runner/work/DAFT/DAFT/.tox/black/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/work/DAFT/DAFT/.tox/black/lib/python3.7/site-packages/black.py", line 4134, in patched_main
    patch_click()
  File "/home/runner/work/DAFT/DAFT/.tox/black/lib/python3.7/site-packages/black.py", line 4123, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/work/DAFT/DAFT/.tox/black/lib/python3.7/site-packages/click/__init__.py)
```
This because of an issue in black and the latest version of click, see https://github.com/psf/black/issues/2964